### PR TITLE
[codex] Fix works card excerpt clamp

### DIFF
--- a/archive-work.php
+++ b/archive-work.php
@@ -81,7 +81,7 @@ $current = get_query_var('genre');
         <?php endif; ?>
 
         <h2><?php the_title(); ?></h2>
-        <p><?php echo wp_trim_words(get_the_content(), 100); ?></p>
+        <p class="work-card-excerpt"><?php echo esc_html(wp_strip_all_tags(strip_shortcodes(get_the_content()))); ?></p>
         <a href="<?php the_permalink(); ?>">詳しく見る</a>
       </article>
     <?php endwhile; else : ?>

--- a/style.css
+++ b/style.css
@@ -281,6 +281,15 @@ body {
     color: #333;
 }
 
+.work-card-excerpt {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    line-clamp: 3;
+    overflow: hidden;
+    text-align: left;
+}
+
 
 /* CTAリンク */
 


### PR DESCRIPTION
## Summary
- Limit Works archive card body text to a 3-line visual excerpt
- Strip shortcodes and HTML before rendering the card excerpt
- Add a dedicated `.work-card-excerpt` line clamp style

## Root Cause
`archive-work.php` used `wp_trim_words(get_the_content(), 100)`, which allowed long body text to appear in the Works card and was especially unreliable for Japanese text where word-based trimming may not produce a short excerpt.

## Validation
- `php -l archive-work.php`

Closes #4