### PR TITLE
[codex] Add works excerpt height fallback

### DIFF
--- a/style.css
+++ b/style.css
@@ -286,6 +286,7 @@ body {
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     line-clamp: 3;
+    max-height: 4.5em;
     overflow: hidden;
     text-align: left;
 }


### PR DESCRIPTION
## Summary
- Add a `max-height: 4.5em` fallback for Works card excerpts

## Why
Production HTML and CSS were already updated, but browser rendering showed `-webkit-line-clamp` was not applying in at least one environment. The fallback caps the excerpt to 3 lines based on the existing `line-height: 1.5`.

## Validation
- Confirmed production HTML includes `.work-card-excerpt`
- Confirmed production CSS includes the clamp rule
- Confirmed cache-busted production rendering still needed a height fallback